### PR TITLE
Adding support for Compact Air PREMIUM with Connect Box

### DIFF
--- a/custom_components/aldes/config_flow.py
+++ b/custom_components/aldes/config_flow.py
@@ -46,6 +46,35 @@ class AldesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return await self._show_config_form(user_input)
 
+    async def async_step_reconfigure(self, user_input=None):
+        """Handle a reconfiguration flow initialized by the user."""
+        self._errors = {}
+
+        #if self._async_current_entries():
+        #    return self.async_abort(reason="single_instance_allowed")
+
+        if user_input is not None:
+            valid = await self._test_credentials(
+                user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
+            )
+            if valid:
+                return self.async_create_entry(
+                    title=user_input[CONF_USERNAME], data=user_input
+                )
+            self._errors["base"] = "auth"
+            return await self._show_config_form(user_input)
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                 {
+                     vol.Required(CONF_USERNAME, default=user_input[CONF_USERNAME]): str,
+                     vol.Required(CONF_PASSWORD, default=user_input[CONF_PASSWORD]): str,
+                 }
+             ),
+             errors=self._errors,
+        )
+
     async def _show_config_form(self, user_input):  # pylint: disable=unused-argument
         """Show the configuration form to edit location data."""
         return self.async_show_form(

--- a/custom_components/aldes/config_flow.py
+++ b/custom_components/aldes/config_flow.py
@@ -58,11 +58,10 @@ class AldesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input[CONF_USERNAME], user_input[CONF_PASSWORD]
             )
             if valid:
-                return self.async_create_entry(
-                    title=user_input[CONF_USERNAME], data=user_input
+                return self.async_update_reload_and_abort(
+                    self._get_reconfigure_entry(),
+                    data_updates=user_input,
                 )
-            self._errors["base"] = "auth"
-            return await self._show_config_form(user_input)
 
         return self.async_show_form(
             step_id="reconfigure",

--- a/custom_components/aldes/config_flow.py
+++ b/custom_components/aldes/config_flow.py
@@ -63,12 +63,14 @@ class AldesFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     data_updates=user_input,
                 )
 
+            self._errors["base"] = "auth"
+
         return self.async_show_form(
             step_id="reconfigure",
             data_schema=vol.Schema(
                  {
-                     vol.Required(CONF_USERNAME, default=user_input[CONF_USERNAME]): str,
-                     vol.Required(CONF_PASSWORD, default=user_input[CONF_PASSWORD]): str,
+                     vol.Required(CONF_USERNAME): str,
+                     vol.Required(CONF_PASSWORD): str,
                  }
              ),
              errors=self._errors,

--- a/custom_components/aldes/const.py
+++ b/custom_components/aldes/const.py
@@ -19,6 +19,7 @@ PLATFORMS: list[Platform] = [
 FRIENDLY_NAMES = {
     "TONE_AIR": "T.One® AIR",
     "EASY_HOME_CONNECT": "EASYHOME PureAir Compact CONNECT",
+    "EASY_HOME_PREMIUM": "EASYHOME PureAir Compact PREMIUM",
 }
 
 TEXT_MODES = {

--- a/custom_components/aldes/manifest.json
+++ b/custom_components/aldes/manifest.json
@@ -1,12 +1,13 @@
 {
     "domain": "aldes",
     "name": "Aldes",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "integration_type": "hub",
-    "documentation": "https://github.com/guix77/homeassistant-aldes",
-    "issue_tracker": "https://github.com/guix77/homeassistant-aldes/issues",
+    "documentation": "https://github.com/arpel/homeassistant-aldes",
+    "issue_tracker": "https://github.com/arpel/homeassistant-aldes/issues",
     "codeowners": [
-      "@guix77"
+      "@guix77",
+      "@arpel"
     ],
     "config_flow": true,
     "iot_class": "cloud_polling"

--- a/custom_components/aldes/sensor.py
+++ b/custom_components/aldes/sensor.py
@@ -203,7 +203,7 @@ async def async_setup_entry(
 
     entities: list[AldesSensorEntity] = []
     for product in coordinator.data:
-        if product["reference"] == "EASY_HOME_CONNECT":
+        if product["reference"] in ["EASY_HOME_CONNECT", "EASY_HOME_PREMIUM"]:
             sensors = EASY_HOME_SENSORS
         elif product["reference"] == "TONE_AIR":
             sensors = TONE_AIR_SENSORS


### PR DESCRIPTION
Use exactly the same pattern (device, sensors) for Compact Air Premium with Connect Box than Compact Air Connect : those are exactly the same units with external or internal connectivity.

Tested on my newly installed unit (onboarding via the Aldes app of course) and working fine : Humidity, Temperature, CO2, Air quality Index, Mode (fan speed), ...